### PR TITLE
Remove extra period in output file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ module.exports = function (options) {
 
         file.sourceMap = opts.compress ? parseSourceMap(css) || file.sourceMap : file.sourceMap;
         file.contents = new Buffer(stripSourceMap(css));
-        file.path = file.path.slice(0, -4) + '.css';
+        file.path = file.path.slice(0, -4) + 'css';
 
         if (!!file.sourceMap) {
           srcMap = convert.fromSource(css);


### PR DESCRIPTION
Removes the extra period added before the '.css' extension. Previously: 'foo..css'; now: 'foo.css'.