### PR TITLE
Do not proceed if tree.toCSS throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ module.exports = function (options) {
           css = tree.toCSS(opts);
         } catch (e) {
           self.emit('error', e);
+          return;
         }
 
         file.sourceMap = opts.compress ? parseSourceMap(css) || file.sourceMap : file.sourceMap;


### PR DESCRIPTION
This is to prevent the task from failing abnormally if input file cannot be parsed with LESS compiler or parsing fails with error.
Do not proceed if `tree.toCSS` throws an error, because otherwise `css` will be undefined and whole task will fail either on `parseSourceMap(css)` or `stripSourceMap(css)` calls.
